### PR TITLE
Make App trait generic over response size

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,17 +1,16 @@
 #![no_std]
 
+use heapless::Vec;
 use trussed_core::InterruptFlag;
 
 mod command;
 
 pub use command::{Command, VendorCommand};
 
-pub type Message = heapless::Vec<u8, 7609>;
-
 /// trait interface for a CTAPHID application.
 /// The application chooses which commands to register to, and will be called upon
 /// when the commands are received in the CTAPHID layer.  Only one application can be registered to a particular command.
-pub trait App<'interrupt> {
+pub trait App<'interrupt, const N: usize> {
     /// Get access to the app interrupter
     fn interrupt(&self) -> Option<&'interrupt InterruptFlag> {
         None
@@ -27,8 +26,8 @@ pub trait App<'interrupt> {
     fn call(
         &mut self,
         command: Command,
-        request: &Message,
-        response: &mut Message,
+        request: &[u8],
+        response: &mut Vec<u8, N>,
     ) -> Result<(), Error>;
 }
 

--- a/dispatch/CHANGELOG.md
+++ b/dispatch/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimize stack usage of `Dispatch::poll`
 - Replace `trussed` dependency with `trussed-core`.
 - Move the `app` and `command` modules into a separate crate, `ctaphid-app`, and re-export it.
+- Make `App` trait generic over the response size.
 
 ## [0.1.1] - 2022-08-22
 - adjust to `interchange` API change

--- a/dispatch/src/lib.rs
+++ b/dispatch/src/lib.rs
@@ -18,7 +18,7 @@ pub mod types;
 
 pub mod app {
     pub use crate::types::AppResult;
-    pub use ctaphid_app::{App, Command, Error, Message};
+    pub use ctaphid_app::{App, Command, Error};
 }
 
 pub mod command {

--- a/dispatch/src/types.rs
+++ b/dispatch/src/types.rs
@@ -1,4 +1,4 @@
-pub use ctaphid_app::{Error, Message};
+pub use ctaphid_app::Error;
 
 // // 7609 bytes is max message size for ctaphid
 // type U6144 = <heapless::consts::U4096 as core::ops::Add<heapless::consts::U2048>>::Output;
@@ -7,6 +7,10 @@ pub use ctaphid_app::{Error, Message};
 // pub type U7609 = heapless::consts::U4096;
 
 // TODO: find reasonable size
+// pub type Message = heapless::Vec<u8, 3072>;
+pub const MESSAGE_SIZE: usize = 7609;
+
+pub type Message = heapless::Vec<u8, MESSAGE_SIZE>;
 pub type AppResult = core::result::Result<(), Error>;
 pub type ShortMessage = heapless::Vec<u8, 1024>;
 


### PR DESCRIPTION
The buffer size is an implementation detail of the dispatch implementation.  Applications should not depend on it.  This patch makes the App trait generic over the response size and changes the request argument to use a slice instead of a reference to a `heapless::Vec`.

If applications need a minimum response size, they can still use a const assertion to enforce it.