### PR TITLE
Make Dispatch generic over buffer size and release v0.3.0

### DIFF
--- a/dispatch/CHANGELOG.md
+++ b/dispatch/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-
+
+## [0.3.0] - 2025-03-21
+
 - Make `Dispatch` generic over the buffer size, rename `MESSAGE_SIZE` to `DEFAULT_MESSAGE_SIZE`, remove the `Message` type and add a `DefaultDispatch` type alias for `Dispatch<_, _, DEFAULT_MESSAGE_SIZE>`.
 
 ## [0.2.0] - 2025-01-08

--- a/dispatch/CHANGELOG.md
+++ b/dispatch/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
--
+
+- Make `Dispatch` generic over the buffer size, rename `MESSAGE_SIZE` to `DEFAULT_MESSAGE_SIZE`, remove the `Message` type and add a `DefaultDispatch` type alias for `Dispatch<_, _, DEFAULT_MESSAGE_SIZE>`.
 
 ## [0.2.0] - 2025-01-08
 

--- a/dispatch/Cargo.toml
+++ b/dispatch/Cargo.toml
@@ -22,6 +22,7 @@ std = ["delog/std"]
 
 log-all = []
 log-none = []
+log-trace = []
 log-info = []
 log-debug = []
 log-warn = []

--- a/dispatch/Cargo.toml
+++ b/dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctaphid-dispatch"
-version = "0.2.0"
+version = "0.3.0"
 description = "Dispatch layer after usbd-ctaphid"
 
 authors.workspace = true

--- a/dispatch/src/lib.rs
+++ b/dispatch/src/lib.rs
@@ -19,4 +19,6 @@ mod types;
 pub use ctaphid_app as app;
 
 pub use dispatch::Dispatch;
-pub use types::{Channel, InterchangeResponse, Message, Requester, Responder, MESSAGE_SIZE};
+pub use types::{Channel, InterchangeResponse, Requester, Responder, DEFAULT_MESSAGE_SIZE};
+
+pub type DefaultDispatch<'pipe, 'interrupt> = Dispatch<'pipe, 'interrupt, DEFAULT_MESSAGE_SIZE>;

--- a/dispatch/src/types.rs
+++ b/dispatch/src/types.rs
@@ -1,31 +1,32 @@
 use ctaphid_app::{Command, Error};
 use heapless_bytes::Bytes;
 
-pub const MESSAGE_SIZE: usize = 7609;
-
-pub type Message = Bytes<MESSAGE_SIZE>;
+pub const DEFAULT_MESSAGE_SIZE: usize = 7609;
 
 /// Wrapper struct that implements [`Default`][] to be able to use [`response_mut`](interchange::Responder::response_mut)
-pub struct InterchangeResponse(pub Result<Message, Error>);
+pub struct InterchangeResponse<const N: usize>(pub Result<Bytes<N>, Error>);
 
-impl Default for InterchangeResponse {
+impl<const N: usize> Default for InterchangeResponse<N> {
     fn default() -> Self {
-        InterchangeResponse(Ok(Message::new()))
+        InterchangeResponse(Ok(Default::default()))
     }
 }
 
-impl From<Result<Message, Error>> for InterchangeResponse {
-    fn from(value: Result<Message, Error>) -> Self {
+impl<const N: usize> From<Result<Bytes<N>, Error>> for InterchangeResponse<N> {
+    fn from(value: Result<Bytes<N>, Error>) -> Self {
         Self(value)
     }
 }
 
-impl From<InterchangeResponse> for Result<Message, Error> {
-    fn from(value: InterchangeResponse) -> Self {
+impl<const N: usize> From<InterchangeResponse<N>> for Result<Bytes<N>, Error> {
+    fn from(value: InterchangeResponse<N>) -> Self {
         value.0
     }
 }
 
-pub type Responder<'pipe> = interchange::Responder<'pipe, (Command, Message), InterchangeResponse>;
-pub type Requester<'pipe> = interchange::Requester<'pipe, (Command, Message), InterchangeResponse>;
-pub type Channel = interchange::Channel<(Command, Message), InterchangeResponse>;
+pub type Responder<'pipe, const N: usize> =
+    interchange::Responder<'pipe, (Command, Bytes<N>), InterchangeResponse<N>>;
+pub type Requester<'pipe, const N: usize> =
+    interchange::Requester<'pipe, (Command, Bytes<N>), InterchangeResponse<N>>;
+pub type Channel<const N: usize> =
+    interchange::Channel<(Command, Bytes<N>), InterchangeResponse<N>>;


### PR DESCRIPTION
The fixed buffer size can be problematic for some use cases, see:
- https://github.com/trussed-dev/ctaphid-dispatch/pull/15

To avoid adding support for different buffer sizes to the crate, we can
just make the dispatch implementation generic over the buffer size.  For
simple cases, a type alias is provided using the old buffer size.